### PR TITLE
Added multiple search screen result pages

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 
 import useCachedResources from './hooks/useCachedResources';
 import useColorScheme from './hooks/useColorScheme';
@@ -16,6 +16,7 @@ export default function App() {
         return (
             <SafeAreaProvider>
                 <Navigation colorScheme={colorScheme} />
+
                 <StatusBar />
             </SafeAreaProvider>
         );

--- a/components/NothingToShow.tsx
+++ b/components/NothingToShow.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import { Text, View } from 'react-native';
+
+const NothingToShow = (props) => {
+    return <View>{props.renderView && <Text>Rendering View Nothing to show</Text>}</View>;
+};
+export default NothingToShow;

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,4 +1,5 @@
 const tintColorLight = '#2f95dc';
+// const tintColorLight = '#fff';
 const tintColorDark = '#fff';
 
 export default {
@@ -7,13 +8,13 @@ export default {
         background: '#fff',
         tint: tintColorLight,
         tabIconDefault: '#ccc',
-        tabIconSelected: tintColorLight
+        tabIconSelected: tintColorLight,
     },
     dark: {
         text: '#fff',
         background: '#000',
         tint: tintColorDark,
         tabIconDefault: '#ccc',
-        tabIconSelected: tintColorDark
-    }
+        tabIconSelected: tintColorDark,
+    },
 };

--- a/constants/Layout.ts
+++ b/constants/Layout.ts
@@ -6,7 +6,7 @@ const height = Dimensions.get('window').height;
 export default {
     window: {
         width,
-        height
+        height,
     },
-    isSmallDevice: width < 375
+    isSmallDevice: width < 375,
 };

--- a/navigation/BottomTabNavigator.tsx
+++ b/navigation/BottomTabNavigator.tsx
@@ -7,33 +7,41 @@ import Colors from '../constants/Colors';
 import useColorScheme from '../hooks/useColorScheme';
 import CameraScanner from '../screens/CameraScanner/CameraScanner';
 import ExternalScanner from '../screens/ExternalScanner/ExternalScanner';
-import { BottomTabParamList, TabOneParamList, TabTwoParamList } from '../types';
+import Search from '../screens/Search/Search';
+import { BottomTabParamList, TabOneParamList, TabTwoParamList, TabThreeParamList } from '../types';
 
-const BottomTab = createBottomTabNavigator<BottomTabParamList>();
+const { Navigator, Screen } = createBottomTabNavigator<BottomTabParamList>();
 
 export default function BottomTabNavigator() {
     const colorScheme = useColorScheme();
 
     return (
-        <BottomTab.Navigator
-            initialRouteName="Camera"
+        <Navigator
+            initialRouteName="ScanGun"
             tabBarOptions={{ activeTintColor: Colors[colorScheme].tint, showLabel: false }}
         >
-            <BottomTab.Screen
+            <Screen
                 name="Camera"
                 component={CameraScannerScreen}
                 options={{
-                    tabBarIcon: ({ color }) => <TabBarIcon name="ios-camera" color={color} />
+                    tabBarIcon: ({ color }) => <TabBarIcon name="ios-camera" color={color} />,
                 }}
             />
-            <BottomTab.Screen
+            <Screen
                 name="ScanGun"
                 component={ScanGunScreen}
                 options={{
-                    tabBarIcon: ({ color }) => <TabBarIcon name="ios-barcode" color={color} />
+                    tabBarIcon: ({ color }) => <TabBarIcon name="ios-barcode" color={color} />,
                 }}
             />
-        </BottomTab.Navigator>
+            <Screen
+                name="Search"
+                component={SearchScreen}
+                options={{
+                    tabBarIcon: ({ color }) => <TabBarIcon name="ios-search" color={color} />,
+                }}
+            />
+        </Navigator>
     );
 }
 
@@ -68,3 +76,17 @@ function ScanGunScreen() {
         </ScanGunStack.Navigator>
     );
 }
+
+const SearchStack = createStackNavigator<TabThreeParamList>();
+
+function SearchScreen() {
+    return (
+        <SearchStack.Navigator>
+            <SearchStack.Screen name="SearchScreen" component={Search} options={{ headerTitle: 'Search' }} />
+        </SearchStack.Navigator>
+    );
+}
+
+//NEW SEARCH STACK NAVIGATOR
+//SEARCH SCREENS (2X SCREEN --- SEARCH SCREEN /// SEARCH RESULT SCREEN)
+//ADD SEARCH TO BOTTOM TAB NAVIGATION

--- a/navigation/LinkingConfiguration.ts
+++ b/navigation/LinkingConfiguration.ts
@@ -8,17 +8,22 @@ export default {
                 screens: {
                     TabOne: {
                         screens: {
-                            TabOneScreen: 'one'
-                        }
+                            TabOneScreen: 'one',
+                        },
                     },
                     TabTwo: {
                         screens: {
-                            TabTwoScreen: 'two'
-                        }
-                    }
-                }
+                            TabTwoScreen: 'two',
+                        },
+                    },
+                    TabThree: {
+                        screen: {
+                            TabThreeScreen: 'Search',
+                        },
+                    },
+                },
             },
-            NotFound: '*'
-        }
-    }
+            NotFound: '*',
+        },
+    },
 };

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -8,6 +8,8 @@ import { RootStackParamList } from '../types';
 import BottomTabNavigator from './BottomTabNavigator';
 import LinkingConfiguration from './LinkingConfiguration';
 
+import SearchResult from '../screens/Search/SearchResult';
+import IndividualItemResult from '../screens/Search/IndividualItemResult';
 export default function Navigation({ colorScheme }: { colorScheme: ColorSchemeName }) {
     return (
         <NavigationContainer linking={LinkingConfiguration} theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
@@ -22,6 +24,8 @@ function RootNavigator() {
     return (
         <Stack.Navigator screenOptions={{ headerShown: false }}>
             <Stack.Screen name="Root" component={BottomTabNavigator} />
+            <Stack.Screen name="SearchResult" component={SearchResult} />
+            <Stack.Screen name="ItemDetails" component={IndividualItemResult} />
             <Stack.Screen name="NotFound" component={NotFoundScreen} options={{ title: 'Oops!' }} />
         </Stack.Navigator>
     );

--- a/screens/Search/IndividualItemResult.tsx
+++ b/screens/Search/IndividualItemResult.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+import itemData from './itemData.json';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+
+const IndividualItemResult = ({ route }) => {
+    const { items } = route.params;
+
+    return (
+        <SafeAreaView>
+            <View style={styles.screen}>
+                <Text>Name: {items.itemName}</Text>
+                <Text>Quantity: {items.quantity}</Text>
+            </View>
+        </SafeAreaView>
+    );
+};
+
+const styles = StyleSheet.create({
+    screen: {
+        padding: 30,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+});
+export default IndividualItemResult;

--- a/screens/Search/Search.tsx
+++ b/screens/Search/Search.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import { View } from '../../components/Themed';
+import itemData from './itemData.json';
+import NothingToShow from '../../components/NothingToShow';
+const Search = ({ navigation }) => {
+    const [itemToGet, setItemToGet] = useState();
+    const [itemFilter, setItemFilter] = useState(itemData.products);
+    const [viewFiltered, setViewFiltered] = useState([]);
+    const [show, setShow] = useState(true);
+
+    const getValue = (text) => {
+        setItemToGet(text);
+    };
+    const searchResultHandler = () => {
+        navigation.navigate('SearchResult', {
+            item: itemToGet,
+        });
+    };
+    return (
+        <View style={styles.inputView}>
+            <TextInput
+                style={styles.input}
+                placeholder="Item Search!"
+                value={itemToGet}
+                onChangeText={(itemToGet) => getValue(itemToGet)}
+            />
+            <TouchableOpacity style={styles.button} activeOpacity={0.2} onPress={searchResultHandler}>
+                <Text style={styles.buttonText}>Search</Text>
+            </TouchableOpacity>
+
+            <NothingToShow renderView={show} />
+
+            {/* {itemToGet !== undefined &&
+                itemToGet.length > 0 &&
+                itemFilter.map(
+                    (items) =>
+                        itemToGet &&
+                        items.itemName.toLowerCase().includes(itemToGet.toLowerCase()) && (
+                            <Text key={Math.random()}>{items.itemName}</Text>
+                        ),
+                )} */}
+        </View>
+    );
+};
+const styles = StyleSheet.create({
+    inputView: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    input: {
+        padding: 10,
+        textAlign: 'center',
+        width: '80%',
+        borderBottomWidth: 1,
+        borderColor: 'black',
+        marginBottom: 20,
+    },
+    button: {
+        height: 50,
+        width: '80%',
+        backgroundColor: '#2196F3',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    buttonText: {
+        color: 'white',
+    },
+});
+export default Search;

--- a/screens/Search/SearchResult.tsx
+++ b/screens/Search/SearchResult.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Text, StyleSheet, View, TouchableWithoutFeedback, Button } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import itemData from './itemData.json';
+const SearchResult = ({ route, navigation }) => {
+    const [itemList, setItemList] = useState(['Biotin', 'Hairtamin', "Puritan's pride "]);
+    const [itemId, setItemId] = useState(0);
+    const { item } = route.params;
+
+    return (
+        <SafeAreaProvider>
+            <View style={style.screen}>
+                <View style={style.itemsBeingMapped}>
+                    {itemData.products.map((items) => (
+                        <View key={Math.random()}>
+                            {items.itemName.toLowerCase().includes(item.toLowerCase()) && (
+                                <Button
+                                    title={items.itemName}
+                                    onPress={() => {
+                                        setItemId(items.itemId);
+                                        navigation.navigate('ItemDetails', { items });
+                                    }}
+                                />
+                            )}
+                        </View>
+                    ))}
+                </View>
+                <Text>You are searching {item}</Text>
+            </View>
+        </SafeAreaProvider>
+    );
+};
+
+const style = StyleSheet.create({
+    screen: {
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginVertical: 100,
+    },
+    itemsBeingMapped: {
+        textAlign: 'center',
+        flexDirection: 'column',
+    },
+    styleMapText: {
+        flex: 1,
+    },
+});
+export default SearchResult;

--- a/screens/Search/itemData.json
+++ b/screens/Search/itemData.json
@@ -1,0 +1,19 @@
+{
+    "products": [
+        { "itemId": 1, "itemName": "Natrol Biotin Full Strength 10,000mcg 100 tablets", "quantity": 100 },
+
+        { "itemId": 2, "itemName": "Hairtamin Full Strength", "quantity": 40 },
+        { "itemId": 3, "itemName": "Puritan's Pride Hair Shampoo", "quantity": 1001 },
+
+        { "itemId": 4, "itemName": "Kirkland Minoxidil 5% Hair regrowth", "quantity": 110 },
+        { "itemId": 5, "itemName": "Natrol Vitamin c", "quantity": 12 },
+
+        { "itemId": 6, "itemName": "Puritan's Pride Vitamin c", "quantity": 14 },
+        { "itemId": 7, "itemName": "Ethika Boxers", "quantity": 5 },
+
+        { "itemId": 8, "itemName": "Supreme Toothpaste", "quantity": 10 },
+        { "itemId": 9, "itemName": "Kirkland foam minoxidil 5%", "quantity": 30 },
+
+        { "itemId": 10, "itemName": "Rogaine", "quantity": 20 }
+    ]
+}

--- a/types.tsx
+++ b/types.tsx
@@ -6,6 +6,7 @@ export type RootStackParamList = {
 export type BottomTabParamList = {
     Camera: string;
     ScanGun: string;
+    Search: string;
 };
 
 export type TabOneParamList = {
@@ -14,4 +15,8 @@ export type TabOneParamList = {
 
 export type TabTwoParamList = {
     ScanGunScreen: undefined;
+};
+
+export type TabThreeParamList = {
+    SearchScreen: undefined;
 };


### PR DESCRIPTION
I have added Search screen which now the app is able to look for data within a json file and retrieve that data.

IndividualItemResult.tsx will show the unqiue information for that item 

now there are two screens Search ( this will basically let you begin typing and return the results on demand) 

the second is SearchResult which on search if you click it it will bring a new page ( but this is not what i want i believe) i want the app to be able to Search for items in the Search screen rather then navigating to a new page, then on the search page you should be able to edit items right from there

